### PR TITLE
Fix #32 duplicated "Like" is shown above attachments on the forum messages

### DIFF
--- a/assets/javascripts/transplant_heart_link_with_counter.js
+++ b/assets/javascripts/transplant_heart_link_with_counter.js
@@ -48,6 +48,9 @@ $(function() {
 
     // append to contextual within the corresponding items.
     if (num_insert === 0) {
+      num_insert += $(link).appendTo("#" + heartable_subject + " > .contextual").length;
+    }
+    if (num_insert === 0) {
       num_insert += $(link).appendTo("#" + heartable_subject + " .contextual").length;
     }
 


### PR DESCRIPTION
Fix #32