### PR TITLE
Fix bug where NoMethodError is occurs when selecting "Like" column on the issue query

### DIFF
--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,18 +11,20 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
-        - '3.0 redmica/redmica@v2.0.0'
-        - '2.7 redmica/redmica@v2.0.0'
+        - '3.1 redmica/redmica@v2.2.2'
+        - '3.0 redmica/redmica@v2.2.2'
+        - '2.7 redmica/redmica@v2.2.2'
         - '2.7 redmica/redmica@v1.3.0'
-        - '3.1 redmine/redmine@5.0.0'
-        - '2.7 redmine/redmine@4.2.5'
-        - '2.6 redmine/redmine@4.2.5'
+        - '3.1 redmine/redmine@5.0.5'
+        - '3.0 redmine/redmine@5.0.5'
+        - '2.7 redmine/redmine@4.2.10'
+        - '2.6 redmine/redmine@4.2.10'
         - '2.6 redmine/redmine@4.1.7'
         - '2.6 redmine/redmine@4.0.9'
         - '2.5 redmine/redmine@4.0.9'
         experimental: [false]
         include:
-          - mat_env: '3.0 redmica/redmica@master'
+          - mat_env: '3.2 redmica/redmica@master'
             experimental: true
     steps:
     - run: |

--- a/app/helpers/hearts_helper.rb
+++ b/app/helpers/hearts_helper.rb
@@ -26,7 +26,7 @@ module HeartsHelper
     return '' unless objects.any?
 
     heart_bool = user && user.logged? && Heart.any_hearted?(objects, user)
-    hearted_users_count = objects.map { |v| v.hearted_users.count }.sum
+    hearted_users_count = objects.map { |v| v.hearted_user_count }.sum
 
     heart_link_with_counter_manual(objects, heart_bool, hearted_users_count, user)
   end

--- a/app/views/hearts/hearted_users.api.rsb
+++ b/app/views/hearts/hearted_users.api.rsb
@@ -4,7 +4,7 @@ api.array :heartables do
     api.heartable do
       render_api_heartable_include(heartable, api)
 
-      api.hearted_users_count heartable.hearts.count
+      api.hearted_users_count heartable.hearted_user_count
       api.array :hearts do
         heartable.hearts.each do |heart|
           api.heart do

--- a/init.rb
+++ b/init.rb
@@ -38,29 +38,29 @@ end
 if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
   Rails.application.config.after_initialize do
     IssueQuery.add_available_column(
-      QueryAssociationColumn.new(:hearts, :count,
-                                 :caption => :hearts_link_label,
-                                 :default_order => 'desc',
-                                 :sortable => lambda {
-                                   query_str = Heart.where(:heartable_type => Issue, :heartable_id => "9999").
-                                     select("COUNT(*)").
-                                     to_sql.sub("9999", "#{Issue.table_name}.id")
-                                   "(#{query_str})"
-                                 })
+      QueryColumn.new(:hearted_user_count,
+                      :caption => :hearts_link_label,
+                      :default_order => 'desc',
+                      :sortable => lambda {
+                        query_str = Heart.where(:heartable_type => Issue, :heartable_id => "9999").
+                          select("COUNT(*)").
+                          to_sql.sub("9999", "#{Issue.table_name}.id")
+                        "(#{query_str})"
+                      })
     )
   end
 else
   ActiveSupport::Reloader.to_prepare do
     IssueQuery.add_available_column(
-      QueryAssociationColumn.new(:hearts, :count,
-                                 :caption => :hearts_link_label,
-                                 :default_order => 'desc',
-                                 :sortable => lambda {
-                                   query_str = Heart.where(:heartable_type => Issue, :heartable_id => "9999").
-                                     select("COUNT(*)").
-                                     to_sql.sub("9999", "#{Issue.table_name}.id")
-                                   "(#{query_str})"
-                                 })
+      QueryColumn.new(:hearted_user_count,
+                      :caption => :hearts_link_label,
+                      :default_order => 'desc',
+                      :sortable => lambda {
+                        query_str = Heart.where(:heartable_type => Issue, :heartable_id => "9999").
+                          select("COUNT(*)").
+                          to_sql.sub("9999", "#{Issue.table_name}.id")
+                        "(#{query_str})"
+                      })
     )
   end
 end

--- a/lib/redmine/acts/heartable.rb
+++ b/lib/redmine/acts/heartable.rb
@@ -84,6 +84,10 @@ module Redmine
           super user_ids
         end
 
+        def hearted_user_count
+          hearted_users.count
+        end
+
         def hearted_by?(user)
           !!(user && self.hearted_user_ids.detect {|uid| uid == user.id })
         end

--- a/test/integration/hearts_hooked_issues_test.rb
+++ b/test/integration/hearts_hooked_issues_test.rb
@@ -48,11 +48,11 @@ class HeartsHookedIssuesTest < Redmine::IntegrationTest
   end
 
   def test_index_with_heart_column
-    get '/issues?set_filter=1&sort=hearts.count:desc,id&c[]=subject&c[]=hearts.count'
+    get '/issues?set_filter=1&sort=hearts.count:desc,id&c[]=subject&c[]=hearted_user_count'
     assert_response :success
     assert_select 'thead > tr > th:nth-child(4)', :text => 'Like'
     assert_select 'td.id', :text => '5'
-    assert_select 'tbody > tr#issue-2:first-child td.hearts-count', :text => '2'
+    assert_select 'tbody > tr#issue-2 td.hearted_user_count', :text => '2'
   end
 
   def test_view


### PR DESCRIPTION
The change in https://www.redmine.org/projects/redmine/repository/svn/revisions/21645 ([#37255](https://www.redmine.org/issues/37255): Information Leak in QueryAssociationColumn/QueryAssociationCustomFieldColumn) makes `visible?` method to be called on the query.

The relations generated by `QueryAssociationColumn.new(:hearts, :count` do not have the `visible?` method. Instead use `QueryColumn.new(:hearted_user_count` and introduce `hearted_user_count` method to Heartable objects.

Note that there is an incompatibility of "Like" query filter ID:  `hearts.count` -> `hearted_user_count`

fix #40