### PR TITLE
Upgrade GitHub workflow: `bundle install --path` and task versions

### DIFF
--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -40,13 +40,14 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
+        bundler-cache: true
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: ./${{ env.PLUGIN_NAME }}
     - name: Set up Redmine
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ env.REDMINE_REPOSITORY }}
         ref: ${{ env.REDMINE_REF }}
@@ -55,20 +56,13 @@ jobs:
     - name: Copy the plugin files to plugin directory
       run: cp -pr ./${{ env.PLUGIN_NAME }} ./redmine/plugins/${{ env.PLUGIN_NAME }}
     - name: Create redmine/config/database.yml
-      uses: DamianReeves/write-file-action@v1.0
+      uses: DamianReeves/write-file-action@v1.2
       with:
         path: ./redmine/config/database.yml
         contents: |
           test:
             adapter: sqlite3
             database: db/redmine_test.db
-
-    - uses: actions/cache@v2
-      with:
-        path: ./redmine/vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('./redmine/**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
 
     - name: Before script
       run: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -40,7 +40,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ env.RUBY_VERSION }}
-        bundler-cache: true
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -64,6 +63,13 @@ jobs:
             adapter: sqlite3
             database: db/redmine_test.db
 
+    - uses: actions/cache@v3
+      with:
+        path: ./redmine/vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('./redmine/**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
     - name: Before script
       run: |
         cd ./redmine
@@ -85,7 +91,7 @@ jobs:
     # HACK sometimes fails login error, so retry 10 times
     # HACK use shell script file to avoid interruption by error
     - name: Prepare test script
-      uses: DamianReeves/write-file-action@v1.0
+      uses: DamianReeves/write-file-action@v1.2
       with:
         path: ./run_test.sh
         contents: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -73,7 +73,8 @@ jobs:
     - name: Before script
       run: |
         cd ./redmine
-        bundle install --path=${BUNDLE_PATH:-vendor/bundle}
+        bundle config --local path ${BUNDLE_PATH:-vendor/bundle}
+        bundle install
         
         mv plugins plugins_bak
         # Initialize redmine


### PR DESCRIPTION
- use `bundle config --local path` instead of legacy `bundle install --path`
- upgrade task versions
  - upgrade actions/checkout@v2 to v3
  - upgrade DamianReeves/write-file-action@v1.0 to v1.2
  - upgrade actions/cache@v2 to v3