### PR TITLE
Refine redmine_hearts:migrate_from_vote_on_issues task (for master)

### DIFF
--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -81,6 +81,13 @@ jobs:
         contents: |
           gem 'loofah', '~> 2.20.0'
       if: contains(fromJSON('["2.6 redmine/redmine@4.1.7", "2.6 redmine/redmine@4.0.9", "2.5 redmine/redmine@4.0.9"]'), matrix.mat_env)
+    - name: "'LoadError: cannot load such file -- blankslate' Issue HACK ref. https://www.redmine.org/issues/40802#note-11"
+      uses: DamianReeves/write-file-action@v1.2
+      with:
+        path: ./redmine/Gemfile.local
+        contents: |
+          gem 'builder', '~> 3.2.4'
+      if: contains(fromJSON('["3.2 redmica/redmica@v2.4.2", "3.2 redmica/redmica@v2.3.2", "3.1 redmica/redmica@v2.2.3", "3.0 redmica/redmica@v2.2.3", "2.7 redmica/redmica@v2.2.3", "2.6 redmine/redmine@4.1.7", "2.6 redmine/redmine@4.0.9", "2.5 redmine/redmine@4.0.9", "2.6 redmine/redmine@4.2.11", "2.7 redmine/redmine@4.2.11"]'), matrix.mat_env)
 
     - name: Before script
       run: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -43,11 +43,11 @@ jobs:
         ruby-version: ${{ env.RUBY_VERSION }}
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: ./${{ env.PLUGIN_NAME }}
     - name: Set up Redmine
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ env.REDMINE_REPOSITORY }}
         ref: ${{ env.REDMINE_REF }}
@@ -56,7 +56,7 @@ jobs:
     - name: Copy the plugin files to plugin directory
       run: cp -pr ./${{ env.PLUGIN_NAME }} ./redmine/plugins/${{ env.PLUGIN_NAME }}
     - name: Create redmine/config/database.yml
-      uses: DamianReeves/write-file-action@v1.2
+      uses: DamianReeves/write-file-action@v1.3
       with:
         path: ./redmine/config/database.yml
         contents: |
@@ -64,7 +64,7 @@ jobs:
             adapter: sqlite3
             database: db/redmine_test.db
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ./redmine/vendor/bundle
         key: ${{ runner.os }}-gems-${{ hashFiles('./redmine/**/Gemfile.lock') }}
@@ -72,7 +72,7 @@ jobs:
           ${{ runner.os }}-gems-
 
     - name: "'LoadError: cannot load such file -- blankslate' Issue HACK ref. https://www.redmine.org/issues/40802#note-11"
-      uses: DamianReeves/write-file-action@v1.2
+      uses: DamianReeves/write-file-action@v1.3
       with:
         path: ./redmine/Gemfile.local
         contents: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,7 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
-        - '3.3 redmica/redmica@v3.0.1'
+        # https://github.com/cat-in-136/redmine_hearts/pull/50 supports redmica-3.0.1
+        #- '3.3 redmica/redmica@v3.0.1'
         - '3.2 redmica/redmica@v2.4.2'
         - '3.2 redmica/redmica@v2.3.2'
         - '3.1 redmica/redmica@v2.2.3'

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -84,7 +84,6 @@ jobs:
 
     - name: Before script
       run: |
-        cd ./redmine
         bundle config --local path ${BUNDLE_PATH:-vendor/bundle}
         bundle install
         
@@ -97,31 +96,27 @@ jobs:
         
         # Execute plugin's migration
         bundle exec rake redmine:plugins NAME=${{ env.PLUGIN_NAME }}
+      working-directory: ./redmine
       env:
         REDMINE_LANG: en
         RAILS_ENV: test
 
     # HACK sometimes fails login error, so retry 10 times
-    # HACK use shell script file to avoid interruption by error
-    - name: Prepare test script
-      uses: DamianReeves/write-file-action@v1.2
-      with:
-        path: ./run_test.sh
-        contents: |
-          #!/bin/sh
-          cd ./redmine
-          for i in `seq 0 9`; do
-            # Execute plugin's test
-            bundle exec rake redmine:plugins:test NAME=${{ env.PLUGIN_NAME }}
-            retval=$?
-            if [ "$retval" -eq 0 ]; then
-              break
-            fi
-            echo "${i}-th test failed; Retry test..."
-          done
-          exit $retval
     - name: Execute test
-      run: sh ./run_test.sh
+      run: |
+        #!/bin/sh
+        for i in `seq 0 9`; do
+          # Execute plugin's test
+          bundle exec rake redmine:plugins:test NAME=${{ env.PLUGIN_NAME }}
+          retval=$?
+          if [ "$retval" -eq 0 ]; then
+            break
+          fi
+          echo "${i}-th test failed; Retry test..."
+        done
+        exit $retval
+      shell: bash {0}
+      working-directory: ./redmine
       env:
         REDMINE_LANG: en
         RAILS_ENV: test

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,13 +11,15 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
+        - '3.3 redmica/redmica@v3.0.1'
+        - '3.2 redmica/redmica@v2.4.2'
         - '3.2 redmica/redmica@v2.3.2'
         - '3.1 redmica/redmica@v2.2.3'
         - '3.0 redmica/redmica@v2.2.3'
         - '2.7 redmica/redmica@v2.2.3'
-        - '3.2 redmine/redmine@5.1.0'
-        - '3.1 redmine/redmine@5.0.6'
-        - '3.0 redmine/redmine@5.0.6'
+        - '3.2 redmine/redmine@5.1.3'
+        - '3.1 redmine/redmine@5.0.9'
+        - '3.0 redmine/redmine@5.0.9'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.1.7'
@@ -25,7 +27,7 @@ jobs:
         - '2.5 redmine/redmine@4.0.9'
         experimental: [false]
         include:
-          - mat_env: '3.2 redmica/redmica@master'
+          - mat_env: '3.3 redmica/redmica@master'
             experimental: true
     steps:
     - run: |

--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -23,9 +23,6 @@ jobs:
         - '3.0 redmine/redmine@5.0.9'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
-        - '2.6 redmine/redmine@4.1.7'
-        - '2.6 redmine/redmine@4.0.9'
-        - '2.5 redmine/redmine@4.0.9'
         experimental: [false]
         include:
           - mat_env: '3.3 redmica/redmica@master'
@@ -74,13 +71,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - name: uninitialized constant Nokogiri::HTML4 Issue HACK ref. https://qiita.com/Mattani/items/c4bcc95a72b69d1c0489
-      uses: DamianReeves/write-file-action@v1.2
-      with:
-        path: ./redmine/Gemfile.local
-        contents: |
-          gem 'loofah', '~> 2.20.0'
-      if: contains(fromJSON('["2.6 redmine/redmine@4.1.7", "2.6 redmine/redmine@4.0.9", "2.5 redmine/redmine@4.0.9"]'), matrix.mat_env)
     - name: "'LoadError: cannot load such file -- blankslate' Issue HACK ref. https://www.redmine.org/issues/40802#note-11"
       uses: DamianReeves/write-file-action@v1.2
       with:

--- a/app/models/heart.rb
+++ b/app/models/heart.rb
@@ -24,9 +24,11 @@ class Heart < ActiveRecord::Base
   belongs_to :heartable, :polymorphic => true
   belongs_to :user
 
+  attribute :skip_validate_user, :boolean
+
   validates_presence_of :user
   validates_uniqueness_of :user_id, :scope => [:heartable_type, :heartable_id]
-  validate :validate_user
+  validate :validate_user, :unless => :skip_validate_user
 
   def self.of_projects(*args)
     projects = args.size > 0 ? args.shift : Project.none

--- a/lib/tasks/redmine_hearts.rake
+++ b/lib/tasks/redmine_hearts.rake
@@ -100,6 +100,7 @@ namespace :redmine_hearts do
           :user => user,
           :created_at => datetime,
           :updated_at => datetime,
+          :skip_validate_user => true,
         )
       end
     end

--- a/lib/tasks/redmine_hearts.rake
+++ b/lib/tasks/redmine_hearts.rake
@@ -88,7 +88,7 @@ namespace :redmine_hearts do
 
     num_of_heart_before_processing = Heart.count
 
-    VoteOnIssue.where('vote_val > 0').each do |vote|
+    VoteOnIssue.where('vote_val > 0').where.not(issue: nil, user: nil).each do |vote|
       issue = vote.issue
       user = vote.user
       datetime = vote.created_at || Time.now


### PR DESCRIPTION
#51 is precedes this pull-request. This pull-request's changes are e0d2189c80b509ab1e50aaf8b287bc6ba676e4ae and 786b05fc83893272049cd6d3559c6822a27af044 .

CI result is here: https://github.com/nishidayuya/redmine_hearts/actions/runs/11682722316

#### About e0d2189c80b509ab1e50aaf8b287bc6ba676e4ae

Sometimes, `vote_on_issues` table has no `issue_id` records. Because [`vote_on_issues.issue_id` does not have NOT NULL constraint (NULL-able)](https://github.com/ojde/redmine-vote_on_issues-plugin/blob/v1.0.3/db/migrate/001_create_vote_on_issues.rb#L6). `vote_on_issues.issue_id` ditto.

So, I want to skip invalid records when migrating from `vote_on_issues`. I create this commit.

#### About 786b05fc83893272049cd6d3559c6822a27af044

My environment has `vote_on_issues` records by locked users. Because I want to migrate them, I create this commit.

I think another solution that is skipping migration for records by locked users. But I want to do data migration as many as possible.
