### PR TITLE
Fix #54: Display only heart icon (and numbers of liked) on mobile contextual area for Redmine 6

### DIFF
--- a/.github/workflows/redmine_plugin.yml
+++ b/.github/workflows/redmine_plugin.yml
@@ -11,17 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         mat_env:
-        - '3.3 redmica/redmica@v3.1.0'
+        - '3.3 redmica/redmica@v3.1.3'
         - '3.3 redmica/redmica@v3.0.4'
-        - '3.2 redmica/redmica@v2.4.2'
-        - '3.2 redmica/redmica@v2.3.2'
-        - '3.1 redmica/redmica@v2.2.3'
-        - '3.0 redmica/redmica@v2.2.3'
-        - '2.7 redmica/redmica@v2.2.3'
-        - '3.3 redmine/redmine@6.0.1'
-        - '3.2 redmine/redmine@5.1.4'
-        - '3.1 redmine/redmine@5.0.10'
-        - '3.0 redmine/redmine@5.0.10'
+        - '3.3 redmine/redmine@6.0.3'
+        - '3.2 redmine/redmine@5.1.6'
+        - '3.1 redmine/redmine@5.0.11'
+        - '3.0 redmine/redmine@5.0.11'
         - '2.7 redmine/redmine@4.2.11'
         - '2.6 redmine/redmine@4.2.11'
         experimental: [false]

--- a/app/helpers/hearts_helper.rb
+++ b/app/helpers/hearts_helper.rb
@@ -53,8 +53,8 @@ module HeartsHelper
     objects = Array.wrap(objects)
 
     css = heart_bool ? 'icon icon-heart' : 'icon icon-heart-off'
-    if defined? hearts_icon_with_label # redmine >= 6.0
-      text = hearts_icon_with_label('heart', l(:hearts_link_label), css_class: 'heart-link-label')
+    if defined? sprite_icon # redmine >= 6.0
+      text = sprite_icon('heart', l(:hearts_link_label), plugin: 'redmine_hearts')
     else
       text = content_tag :span, l(:hearts_link_label), :class => 'heart-link-label'
     end
@@ -134,12 +134,6 @@ module HeartsHelper
 
   if defined? IconsHelper # redmine >= 6.0
     include IconsHelper
-    def hearts_icon_with_label(icon_name, label_text, icon_only: false, size: 18, css_class: nil)
-      label_classes = ["icon-label"]
-      label_classes << "hidden" if icon_only
-      plugin = 'redmine_hearts'
-      sprite_icon(icon_name, size: size, css_class: css_class, plugin: plugin) + content_tag(:span, label_text, class: label_classes.join(' '))
-    end
   end
 
 end

--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -36,9 +36,17 @@
     border-radius: 3px;
   }
 
+  /* redmine < 6.0 */
   #history .journal .contextual .heart-link-with-count .heart-link-label,
   .message.reply .contextual .heart-link-with-count .heart-link-label,
   .news-article .contextual .heart-link-with-count .heart-link-label {
+    display: none;
+  }
+
+  /* redmine < 6.0 */
+  #history .journal .contextual .heart-link-with-count .icon > .icon-label,
+  .message.reply .contextual .heart-link-with-count .icon > .icon-label,
+  .news-article .contextual .heart-link-with-count .icon > .icon-label {
     display: none;
   }
 }

--- a/test/unit/helpers/hearts_helper_test.rb
+++ b/test/unit/helpers/hearts_helper_test.rb
@@ -56,7 +56,7 @@ class HeartsHelperTest < Redmine::HelperTest
       safe_join(
         [
           link_to(
-            hearts_icon_with_label('heart', 'Like', css_class: 'heart-link-label'),
+            sprite_icon('heart', 'Like', plugin: 'redmine_hearts'),
             heart_url(:object_id => 1, :object_type => 'issue', :only_path => true),
             :remote => true, :method => 'post', :class => "icon icon-heart-off"
           ),
@@ -93,7 +93,7 @@ class HeartsHelperTest < Redmine::HelperTest
       safe_join(
         [
           content_tag(:span,
-                      hearts_icon_with_label('heart', 'Like', css_class: 'heart-link-label'),
+                      sprite_icon('heart', 'Like', plugin: 'redmine_hearts'),
                       :class => "icon icon-heart-off"),
           content_tag(:span, "0", :class => "heart-count-number"),
         ],
@@ -129,7 +129,7 @@ class HeartsHelperTest < Redmine::HelperTest
       safe_join(
         [
           link_to(
-            hearts_icon_with_label('heart', 'Like', css_class: 'heart-link-label'),
+            sprite_icon('heart', 'Like', plugin: 'redmine_hearts'),
             heart_url(:object_id => [1, 3], :object_type => 'issue', :only_path => true),
             :remote => true, :method => 'post', :class => "icon icon-heart-off"
           ),
@@ -179,7 +179,7 @@ class HeartsHelperTest < Redmine::HelperTest
       safe_join(
         [
           link_to(
-            hearts_icon_with_label('heart', 'Like', css_class: 'heart-link-label'),
+            sprite_icon('heart', 'Like', plugin: 'redmine_hearts'),
             heart_url(:object_id => 1, :object_type => 'issue', :only_path => true),
             :remote => true, :method => 'delete', :class => "icon icon-heart"
           ),
@@ -219,7 +219,7 @@ class HeartsHelperTest < Redmine::HelperTest
       safe_join(
         [
           content_tag(:span,
-                      hearts_icon_with_label('heart', 'Like', css_class: 'heart-link-label'),
+                      sprite_icon('heart', 'Like', plugin: 'redmine_hearts'),
                       :class => "icon icon-heart-off"),
           content_tag(:span, "1", :class => "heart-count-number"),
         ],
@@ -300,10 +300,4 @@ class HeartsHelperTest < Redmine::HelperTest
   test "#link_to_heartable_with_nil" do
     assert_raises { link_to_heartable(nil) }
   end
-
-  test "#hearts_icon_with_label" do
-    expected = sprite_icon('heart', size: 18, plugin: 'redmine_hearts') +
-      content_tag(:span, 'Like', class: 'icon-label')
-    assert_equal expected, hearts_icon_with_label('heart', 'Like')
-  end if defined? IconsHelper # redmine >= 6.0
 end


### PR DESCRIPTION
This PR fixes #54 by ensuring that only the heart icon is displayed in the contextual area on mobile devices for Redmine 6, removing the accompanying text in this case.

- **CSS Updates:**
  - Removed the `heart-link-label` class.
  - Added CSS rules to hide the text label on mobile views.
- **Helper Refactoring:**
  - Updated `hearts_helper.rb` to use `sprite_icon` instead of `hearts_icon_with_label`.
- **Tests Adjusted:**
  - Modified `hearts_helper_test.rb` to reflect the helper changes.
- **Workflow Updates:**
  - Updated GitHub Actions to support newer Redmine versions and remove unsupported Ruby versions.