### PR TITLE
fix migration error on redmine5 with lib where ApplicationRecord is defined

### DIFF
--- a/lib/redmine/acts/heartable.rb
+++ b/lib/redmine/acts/heartable.rb
@@ -98,5 +98,7 @@ module Redmine
   end
 end
 
-(defined?(ApplicationRecord) == 'constant' ? ApplicationRecord : ActiveRecord::Base).send(:include, Redmine::Acts::Heartable)
+# Extend ApplicationRecord if Redmine > 6, ActiveRecord::Base if Redmine < 6.
+# https://www.redmine.org/issues/38975
+(Redmine::VERSION::MAJOR > 6 ? ApplicationRecord : ActiveRecord::Base).send(:include, Redmine::Acts::Heartable)
 


### PR DESCRIPTION
In redmine 6, it is necessary to deal with https://www.redmine.org/issues/38975. In the current implementation, the existence of ApplicationRecord is referenced to determine the target to be extended (59f151e9297999b7827399a3fa6413d2fe5386f5). But it seems inappropriate for the following two reasons:

1. this was an inappropriate way of making a decision because ApplicationRecord itself existed as of rails 5.
2. Side effects occur if some sloppy library which defined ApplicationRecord in is required in the redmine system. For example, the redmineup library, which depends on all the redmineup plugins, [does this](https://www.rubydoc.info/gems/redmineup/1.0.10/ApplicationRecord).

fix #56 