### PR TITLE
Skip migration if user is already deleted

### DIFF
--- a/lib/tasks/redmine_hearts.rake
+++ b/lib/tasks/redmine_hearts.rake
@@ -153,6 +153,9 @@ namespace :redmine_hearts do
     num_of_skipped_heartable_due_to_unsupported = 0
 
     Heart.all.each do |heart|
+      # skip if reacted by deleted user
+      next unless heart.user
+
       heartable = heart.heartable
       user = heart.user
       created_at = heart.created_at


### PR DESCRIPTION
👋  Thank you for maintaining this plugin.

I used this for https://bugs.ruby-lang.org/ that is the official issue tracker of the Ruby language.

I try to migrate hearts to built-in like with your migration task. But it has issue with deleted user like this:

```
ActiveRecord::NotNullViolation: PG::NotNullViolation: ERROR:  null value in column "user_id" of relation "reactions" violates not-null constraint (ActiveRecord::NotNullViolation)
DETAIL:  Failing row contains (292, Issue, 19567, null, 2023-04-01 06:31:07.968302, 2023-04-01 06:31:07.968302).
```

I added simple skip logic for that.